### PR TITLE
[Docs] Fixed YuNet model visualization link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It is the training program for [libfacedetection](https://github.com/ShiqiYu/libfacedetection). The source code is based on [FaceBoxes.PyTorch](https://github.com/sfzhang15/FaceBoxes.PyTorch) and [ssd.pytorch](https://github.com/amdegroot/ssd.pytorch).
 
-Visualization of our network architecture: [[netron]](https://netron.app/?url=https://raw.githubusercontent.com/ShiqiYu/libfacedetection.train/master/tasks/task1/onnx/YuFaceDetectNet.onnx).
+Visualization of our network architecture: [[netron]](https://netron.app/?url=https://raw.githubusercontent.com/ShiqiYu/libfacedetection.train/master/onnx/yunet_yunet_final_dynamic_simplify.onnx).
 
 
 ### Contents


### PR DESCRIPTION
Closes #51 

**Fix:** 
I have changed the visualization link to point to the [yunet_yunet_final_dynamic_simplify.onnx](https://github.com/ShiqiYu/libfacedetection.train/blob/master/onnx/yunet_yunet_final_dynamic_simplify.onnx) model.